### PR TITLE
feat: add domain entities and configure DbContext for pet grooming API

### DIFF
--- a/src/BookPetGroomingAPI.Domain/Entities/Appointment.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/Appointment.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    /// <summary>
+    /// Represents a grooming appointment for a pet.
+    /// </summary>
+    public class Appointment
+    {
+        public int AppointmentId { get; set; }
+        public int PetId { get; set; }
+        public int GroomerId { get; set; }
+        public DateTime AppointmentDate { get; set; }
+        public required string Status { get; set; }
+        public required string Notes { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        // Navigation properties
+        public Pet? Pet { get; set; }
+        public Groomer? Groomer { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Domain/Entities/Breed.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/Breed.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    public class Breed
+    {
+        public int BreedId { get; set; }
+        public required string Name { get; set; }
+        public required string Species { get; set; }
+        public required string CoatType { get; set; }
+        public int GroomingDifficulty { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Domain/Entities/Customer.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/Customer.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    public class Customer
+    {
+        public int CustomerId { get; set; }
+        public required string FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Address { get; set; }
+        public int? PreferredGroomerId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        // Navigation properties
+        public Groomer? PreferredGroomer { get; set; }
+        public ICollection<Pet>? Pets { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Domain/Entities/Groomer.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/Groomer.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    public class Groomer
+    {
+        public int GroomerId { get; set; }
+        public required string FirstName { get; set; }
+        public required string LastName { get; set; }
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Specialization { get; set; }
+        public int YearsOfExperience { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        // Navigation properties
+        public ICollection<Customer>? Customers { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Domain/Entities/Notification.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/Notification.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    /// <summary>
+    /// Represents a notification sent to a customer or groomer.
+    /// </summary>
+    public class Notification
+    {
+        public int NotificationId { get; set; }
+        public int? CustomerId { get; set; }
+        public int? GroomerId { get; set; }
+        public string? Message { get; set; }
+        public bool IsRead { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? ReadAt { get; set; }
+
+        // Navigation properties
+        public Customer? Customer { get; set; }
+        public Groomer? Groomer { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Domain/Entities/Pet.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/Pet.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    /// <summary>
+    /// Represents a pet owned by a customer.
+    /// </summary>
+    public class Pet
+    {
+        public int PetId { get; set; }
+        public required string Name { get; set; }
+        public DateTime DateOfBirth { get; set; }
+        public required string Gender { get; set; }
+        public int CustomerId { get; set; }
+        public int BreedId { get; set; }
+        public int CategoryId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        // Navigation properties
+        public Customer? Owner { get; set; }
+        public Breed? Breed { get; set; }
+        public PetCategory? Category { get; set; }
+        public ICollection<Appointment>? Appointments { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Domain/Entities/PetCategory.cs
+++ b/src/BookPetGroomingAPI.Domain/Entities/PetCategory.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BookPetGroomingAPI.Domain.Entities
+{
+    public class PetCategory
+    {
+        public int CategoryId { get; set; }
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/src/BookPetGroomingAPI.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/BookPetGroomingAPI.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -3,14 +3,16 @@ using BookPetGroomingAPI.Domain.Entities;
 
 namespace BookPetGroomingAPI.Infrastructure.Persistence;
 
-public class ApplicationDbContext : DbContext
+public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options)
 {
-    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-        : base(options)
-    {
-    }
-
     public DbSet<Product> Products => Set<Product>();
+    public DbSet<Breed> Breeds => Set<Breed>();
+    public DbSet<PetCategory> PetCategories => Set<PetCategory>();
+    public DbSet<Groomer> Groomers => Set<Groomer>();
+    public DbSet<Customer> Customers => Set<Customer>();
+    public DbSet<Pet> Pets => Set<Pet>();
+    public DbSet<Appointment> Appointments => Set<Appointment>();
+    public DbSet<Notification> Notifications => Set<Notification>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -26,6 +28,120 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.Stock).IsRequired();
             entity.Property(e => e.Active).IsRequired();
             entity.Property(e => e.CreationDate).IsRequired();
+        });
+
+        // Breed entity configuration
+        modelBuilder.Entity<Breed>(entity =>
+        {
+            entity.HasKey(e => e.BreedId);
+            entity.Property(e => e.Name).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Species).HasMaxLength(50);
+            entity.Property(e => e.CoatType).HasMaxLength(50);
+            entity.Property(e => e.GroomingDifficulty).IsRequired();
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt).IsRequired();
+        });
+
+        // PetCategory entity configuration
+        modelBuilder.Entity<PetCategory>(entity =>
+        {
+            entity.HasKey(e => e.CategoryId);
+            entity.Property(e => e.Name).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(250);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt).IsRequired();
+        });
+
+        // Groomer entity configuration
+        modelBuilder.Entity<Groomer>(entity =>
+        {
+            entity.HasKey(e => e.GroomerId);
+            entity.Property(e => e.FirstName).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.LastName).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Email).HasMaxLength(150);
+            entity.Property(e => e.Phone).HasMaxLength(20);
+            entity.Property(e => e.Specialization).HasMaxLength(100);
+            entity.Property(e => e.YearsOfExperience).IsRequired();
+            entity.Property(e => e.IsActive).IsRequired();
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt).IsRequired();
+        });
+
+        // Customer entity configuration
+        modelBuilder.Entity<Customer>(entity =>
+        {
+            entity.HasKey(e => e.CustomerId);
+            entity.Property(e => e.FirstName).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.LastName).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Email).HasMaxLength(150);
+            entity.Property(e => e.Phone).HasMaxLength(20);
+            entity.Property(e => e.Address).HasMaxLength(250);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt).IsRequired();
+            entity.HasOne(e => e.PreferredGroomer)
+                  .WithMany(g => g.Customers)
+                  .HasForeignKey(e => e.PreferredGroomerId)
+                  .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // Pet entity configuration
+        modelBuilder.Entity<Pet>(entity =>
+        {
+            entity.HasKey(e => e.PetId);
+            entity.Property(e => e.Name).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.DateOfBirth).IsRequired();
+            entity.Property(e => e.Gender).HasMaxLength(10);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt).IsRequired();
+            entity.HasOne(e => e.Owner)
+                  .WithMany(c => c.Pets)
+                  .HasForeignKey(e => e.CustomerId)
+                  .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.Breed)
+                  .WithMany()
+                  .HasForeignKey(e => e.BreedId)
+                  .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.Category)
+                  .WithMany()
+                  .HasForeignKey(e => e.CategoryId)
+                  .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        // Appointment entity configuration
+        modelBuilder.Entity<Appointment>(entity =>
+        {
+            entity.HasKey(e => e.AppointmentId);
+            entity.Property(e => e.AppointmentDate).IsRequired();
+            entity.Property(e => e.Status).HasMaxLength(50);
+            entity.Property(e => e.Notes).HasMaxLength(500);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt).IsRequired();
+            entity.HasOne(e => e.Pet)
+                  .WithMany(p => p.Appointments)
+                  .HasForeignKey(e => e.PetId)
+                  .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.Groomer)
+                  .WithMany()
+                  .HasForeignKey(e => e.GroomerId)
+                  .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        // Notification entity configuration
+        modelBuilder.Entity<Notification>(entity =>
+        {
+            entity.HasKey(e => e.NotificationId);
+            entity.Property(e => e.Message).HasMaxLength(500).IsRequired();
+            entity.Property(e => e.IsRead).IsRequired();
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.ReadAt);
+            entity.HasOne(e => e.Customer)
+                  .WithMany()
+                  .HasForeignKey(e => e.CustomerId)
+                  .OnDelete(DeleteBehavior.SetNull);
+            entity.HasOne(e => e.Groomer)
+                  .WithMany()
+                  .HasForeignKey(e => e.GroomerId)
+                  .OnDelete(DeleteBehavior.SetNull);
         });
     }
 }


### PR DESCRIPTION
This commit introduces new domain entities for the pet grooming API, including `PetCategory`, `Breed`, `Notification`, `Customer`, `Appointment`, `Groomer`, and `Pet`. Additionally, the `ApplicationDbContext` has been updated to include DbSet properties for these entities and configure their relationships and constraints using Fluent API.