### PR TITLE
feat(rate-limiting): add rate limiting middleware and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 *.userosscache
 *.sln.docstates
 src/BookPetGroomingAPI.API/Logs/
+docs
+examples
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/BookPetGroomingAPI.API/Attributes/RateLimitAttribute.cs
+++ b/src/BookPetGroomingAPI.API/Attributes/RateLimitAttribute.cs
@@ -1,0 +1,163 @@
+using BookPetGroomingAPI.API.Configuration;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Net;
+
+namespace BookPetGroomingAPI.API.Attributes;
+
+/// <summary>
+/// Attribute to apply specific rate limiting rules to controllers or actions
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public class RateLimitAttribute : ActionFilterAttribute
+{
+    private readonly int _maxRequests;
+    private readonly int _windowInSeconds;
+    private readonly bool _applyGlobalLimits;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimitAttribute"/> class
+    /// </summary>
+    /// <param name="maxRequests">Maximum number of requests allowed in the time window</param>
+    /// <param name="windowInSeconds">Time window in seconds</param>
+    /// <param name="applyGlobalLimits">Whether to also apply global rate limits defined in configuration</param>
+    public RateLimitAttribute(int maxRequests, int windowInSeconds = 60, bool applyGlobalLimits = true)
+    {
+        _maxRequests = maxRequests;
+        _windowInSeconds = windowInSeconds;
+        _applyGlobalLimits = applyGlobalLimits;
+    }
+
+    /// <summary>
+    /// Executes before the action method is invoked
+    /// </summary>
+    /// <param name="context">The action executing context</param>
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        // Get required services
+        var cache = context.HttpContext.RequestServices.GetRequiredService<IMemoryCache>();
+        var options = context.HttpContext.RequestServices.GetRequiredService<IOptions<RateLimitingOptions>>().Value;
+
+        // Skip if rate limiting is disabled or endpoint is whitelisted
+        var endpoint = context.ActionDescriptor.DisplayName;
+        if (endpoint != null && options.EndpointWhitelist.Any(e => endpoint.Contains(e, StringComparison.OrdinalIgnoreCase)))
+        {
+            base.OnActionExecuting(context);
+            return;
+        }
+
+        // Get client identifier (IP or user ID)
+        string clientId = GetClientIdentifier(context.HttpContext, options);
+
+        // Check if rate limit is exceeded
+        var cacheKey = $"ratelimit_attr_{clientId}_{context.ActionDescriptor.Id}";
+        if (!cache.TryGetValue(cacheKey, out SlidingWindowCounter counter))
+        {
+            counter = new SlidingWindowCounter(_windowInSeconds);
+            cache.Set(cacheKey, counter, TimeSpan.FromSeconds(_windowInSeconds * 2));
+        }
+
+        // Increment counter and check if limit exceeded
+        if (counter.Increment() > _maxRequests)
+        {
+            // Set response for rate limit exceeded
+            context.Result = new Microsoft.AspNetCore.Mvc.ContentResult
+            {
+                StatusCode = (int)HttpStatusCode.TooManyRequests,
+                ContentType = "application/json",
+                Content = System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    error = "Too many requests",
+                    retryAfter = _windowInSeconds,
+                    message = $"Rate limit exceeded. Try again in {_windowInSeconds} seconds."
+                })
+            };
+
+            // Add headers
+            context.HttpContext.Response.Headers.Append("Retry-After", _windowInSeconds.ToString());
+            context.HttpContext.Response.Headers.Append("X-RateLimit-Limit", _maxRequests.ToString());
+            context.HttpContext.Response.Headers.Append("X-RateLimit-Remaining", "0");
+            context.HttpContext.Response.Headers.Append("X-RateLimit-Reset", counter.WindowResetTime.ToString("o"));
+
+            return;
+        }
+
+        // Add rate limit headers
+        int remaining = Math.Max(0, _maxRequests - counter.Count);
+        context.HttpContext.Response.Headers.Append("X-RateLimit-Limit", _maxRequests.ToString());
+        context.HttpContext.Response.Headers.Append("X-RateLimit-Remaining", remaining.ToString());
+        context.HttpContext.Response.Headers.Append("X-RateLimit-Reset", counter.WindowResetTime.ToString("o"));
+
+        base.OnActionExecuting(context);
+    }
+
+    private string GetClientIdentifier(HttpContext context, RateLimitingOptions options)
+    {
+        // Use user ID for authenticated users if user rate limiting is enabled
+        if (options.EnableUserRateLimiting && context.User.Identity?.IsAuthenticated == true)
+        {
+            var userId = context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
+            if (!string.IsNullOrEmpty(userId.ToString()))
+            {
+                return $"user_{userId}";
+            }
+        }
+
+        // Fall back to IP-based rate limiting
+        string? clientIp = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (string.IsNullOrEmpty(clientIp))
+        {
+            clientIp = context.Request.Headers["X-Real-IP"].FirstOrDefault();
+        }
+        if (string.IsNullOrEmpty(clientIp))
+        {
+            clientIp = context.Connection.RemoteIpAddress?.ToString();
+        }
+
+        return $"ip_{clientIp ?? "unknown"}";
+    }
+
+    /// <summary>
+    /// Helper class for implementing a sliding window counter
+    /// </summary>
+    private class SlidingWindowCounter
+    {
+        private readonly int _windowSeconds;
+        private readonly Queue<DateTime> _requests = new();
+        private readonly object _lock = new();
+
+        public int Count => _requests.Count;
+        public DateTime WindowResetTime { get; private set; }
+
+        public SlidingWindowCounter(int windowSeconds)
+        {
+            _windowSeconds = windowSeconds;
+            WindowResetTime = DateTime.UtcNow.AddSeconds(windowSeconds);
+        }
+
+        public int Increment()
+        {
+            lock (_lock)
+            {
+                var now = DateTime.UtcNow;
+                var windowStart = now.AddSeconds(-_windowSeconds);
+
+                // Remove requests outside the current window
+                while (_requests.Count > 0 && _requests.Peek() < windowStart)
+                {
+                    _requests.Dequeue();
+                }
+
+                // Add the current request
+                _requests.Enqueue(now);
+
+                // Update the window reset time
+                WindowResetTime = now.AddSeconds(_windowSeconds);
+
+                return _requests.Count;
+            }
+        }
+    }
+}

--- a/src/BookPetGroomingAPI.API/Configuration/RateLimitingOptions.cs
+++ b/src/BookPetGroomingAPI.API/Configuration/RateLimitingOptions.cs
@@ -1,0 +1,42 @@
+namespace BookPetGroomingAPI.API.Configuration;
+
+/// <summary>
+/// Configuration options for the rate limiting middleware
+/// </summary>
+public class RateLimitingOptions
+{
+    /// <summary>
+    /// Gets or sets the general rate limit window in seconds
+    /// </summary>
+    public int WindowInSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Gets or sets the maximum number of requests allowed within the window
+    /// </summary>
+    public int MaxRequests { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets whether to enable per-client IP rate limiting
+    /// </summary>
+    public bool EnableIpRateLimiting { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to enable per-user rate limiting (requires authentication)
+    /// </summary>
+    public bool EnableUserRateLimiting { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of requests allowed for authenticated users
+    /// </summary>
+    public int AuthenticatedMaxRequests { get; set; } = 200;
+
+    /// <summary>
+    /// Gets or sets the list of IP addresses that should be excluded from rate limiting
+    /// </summary>
+    public List<string> IpWhitelist { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the list of endpoints that should be excluded from rate limiting
+    /// </summary>
+    public List<string> EndpointWhitelist { get; set; } = new List<string>();
+}

--- a/src/BookPetGroomingAPI.API/Extensions/RateLimitingExtensions.cs
+++ b/src/BookPetGroomingAPI.API/Extensions/RateLimitingExtensions.cs
@@ -1,0 +1,44 @@
+using BookPetGroomingAPI.API.Configuration;
+using BookPetGroomingAPI.API.Middlewares;
+using Microsoft.Extensions.Options;
+
+namespace BookPetGroomingAPI.API.Extensions;
+
+/// <summary>
+/// Extension methods for configuring rate limiting services
+/// </summary>
+public static class RateLimitingExtensions
+{
+    /// <summary>
+    /// Adds rate limiting services to the service collection
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <param name="configuration">The configuration</param>
+    /// <returns>The service collection for chaining</returns>
+    public static IServiceCollection AddRateLimiting(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Configure rate limiting options from appsettings.json
+        services.Configure<RateLimitingOptions>(configuration.GetSection("RateLimiting"));
+
+        // Add memory cache for storing rate limit counters
+        services.AddMemoryCache();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the rate limiting middleware to the application pipeline
+    /// </summary>
+    /// <param name="app">The application builder</param>
+    /// <returns>The application builder for chaining</returns>
+    public static IApplicationBuilder UseRateLimiting(this IApplicationBuilder app)
+    {
+        // Get the options to check if rate limiting is enabled
+        var options = app.ApplicationServices.GetRequiredService<IOptions<RateLimitingOptions>>().Value;
+
+        // Apply the rate limiting middleware
+        app.UseMiddleware<RateLimitingMiddleware>();
+
+        return app;
+    }
+}

--- a/src/BookPetGroomingAPI.API/Middlewares/RateLimitingMiddleware.cs
+++ b/src/BookPetGroomingAPI.API/Middlewares/RateLimitingMiddleware.cs
@@ -1,0 +1,227 @@
+using BookPetGroomingAPI.API.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace BookPetGroomingAPI.API.Middlewares;
+
+/// <summary>
+/// Middleware for implementing rate limiting to protect API endpoints
+/// </summary>
+public class RateLimitingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RateLimitingMiddleware> _logger;
+    private readonly IMemoryCache _cache;
+    private readonly RateLimitingOptions _options;
+    private readonly ConcurrentDictionary<string, DateTime> _lastErrorNotificationTimes = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimitingMiddleware"/> class
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline</param>
+    /// <param name="logger">The logger</param>
+    /// <param name="cache">The memory cache for storing rate limit counters</param>
+    /// <param name="options">The rate limiting configuration options</param>
+    public RateLimitingMiddleware(RequestDelegate next, ILogger<RateLimitingMiddleware> logger,
+        IMemoryCache cache, IOptions<RateLimitingOptions> options)
+    {
+        _next = next;
+        _logger = logger;
+        _cache = cache;
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// Processes the request and applies rate limiting rules
+    /// </summary>
+    /// <param name="context">The HTTP context</param>
+    /// <returns>A task representing the asynchronous operation</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Skip rate limiting for whitelisted endpoints
+        var endpoint = context.GetEndpoint()?.DisplayName;
+        if (endpoint != null && _options.EndpointWhitelist.Any(e => endpoint.Contains(e, StringComparison.OrdinalIgnoreCase)))
+        {
+            await _next(context);
+            return;
+        }
+
+        // Skip rate limiting for whitelisted IPs
+        var clientIp = GetClientIpAddress(context);
+        if (_options.IpWhitelist.Contains(clientIp))
+        {
+            await _next(context);
+            return;
+        }
+
+        // Determine the client identifier based on configuration
+        string clientId = GetClientIdentifier(context, clientIp);
+
+        // Get the appropriate rate limit based on authentication status
+        int maxRequests = context.User.Identity?.IsAuthenticated == true
+            ? _options.AuthenticatedMaxRequests
+            : _options.MaxRequests;
+
+        // Check if the client has exceeded the rate limit
+        if (IsRateLimitExceeded(clientId, maxRequests))
+        {
+            await HandleRateLimitExceeded(context, clientId);
+            return;
+        }
+
+        // Add rate limit headers to the response
+        AddRateLimitHeaders(context, clientId, maxRequests);
+
+        // Continue with the next middleware in the pipeline
+        await _next(context);
+    }
+
+    private string GetClientIdentifier(HttpContext context, string clientIp)
+    {
+        // Use user ID for authenticated users if user rate limiting is enabled
+        if (_options.EnableUserRateLimiting && context.User.Identity?.IsAuthenticated == true)
+        {
+            var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!string.IsNullOrEmpty(userId))
+            {
+                return $"user_{userId}";
+            }
+        }
+
+        // Fall back to IP-based rate limiting if enabled
+        if (_options.EnableIpRateLimiting)
+        {
+            return $"ip_{clientIp}";
+        }
+
+        // Default to a global rate limit if neither is enabled
+        return "global";
+    }
+
+    private string GetClientIpAddress(HttpContext context)
+    {
+        // Try to get the client IP from various headers or connection info
+        string? clientIp = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (string.IsNullOrEmpty(clientIp))
+        {
+            clientIp = context.Request.Headers["X-Real-IP"].FirstOrDefault();
+        }
+        if (string.IsNullOrEmpty(clientIp))
+        {
+            clientIp = context.Connection.RemoteIpAddress?.ToString();
+        }
+
+        return clientIp ?? "unknown";
+    }
+
+    private bool IsRateLimitExceeded(string clientId, int maxRequests)
+    {
+        var cacheKey = $"ratelimit_{clientId}";
+
+        // Get or create a counter for the client
+        if (!_cache.TryGetValue(cacheKey, out SlidingWindowCounter counter))
+        {
+            counter = new SlidingWindowCounter(_options.WindowInSeconds);
+            _cache.Set(cacheKey, counter, TimeSpan.FromSeconds(_options.WindowInSeconds * 2));
+        }
+
+        // Increment the counter and check if the limit is exceeded
+        return counter.Increment() > maxRequests;
+    }
+
+    private async Task HandleRateLimitExceeded(HttpContext context, string clientId)
+    {
+        // Set the response status code to 429 (Too Many Requests)
+        context.Response.StatusCode = (int)HttpStatusCode.TooManyRequests;
+        context.Response.ContentType = "application/json";
+
+        // Add retry-after header
+        context.Response.Headers.Append("Retry-After", _options.WindowInSeconds.ToString());
+
+        // Log the rate limit exceeded event (with throttling to prevent log flooding)
+        LogRateLimitExceeded(clientId);
+
+        // Return a JSON response with information about the rate limit
+        var response = new
+        {
+            error = "Too many requests",
+            retryAfter = _options.WindowInSeconds,
+            message = $"Rate limit exceeded. Try again in {_options.WindowInSeconds} seconds."
+        };
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+    }
+
+    private void LogRateLimitExceeded(string clientId)
+    {
+        // Throttle logging to prevent log flooding
+        var now = DateTime.UtcNow;
+        var lastLogTime = _lastErrorNotificationTimes.GetOrAdd(clientId, now.AddMinutes(-10));
+
+        if ((now - lastLogTime).TotalMinutes >= 1)
+        {
+            _logger.LogWarning("Rate limit exceeded for client {ClientId}", clientId);
+            _lastErrorNotificationTimes[clientId] = now;
+        }
+    }
+
+    private void AddRateLimitHeaders(HttpContext context, string clientId, int maxRequests)
+    {
+        var cacheKey = $"ratelimit_{clientId}";
+        if (_cache.TryGetValue(cacheKey, out SlidingWindowCounter counter))
+        {
+            int remaining = Math.Max(0, maxRequests - counter.Count);
+
+            // Add standard rate limit headers
+            context.Response.Headers.Append("X-RateLimit-Limit", maxRequests.ToString());
+            context.Response.Headers.Append("X-RateLimit-Remaining", remaining.ToString());
+            context.Response.Headers.Append("X-RateLimit-Reset", counter.WindowResetTime.ToString("o"));
+        }
+    }
+
+    /// <summary>
+    /// Helper class for implementing a sliding window counter
+    /// </summary>
+    private class SlidingWindowCounter
+    {
+        private readonly int _windowSeconds;
+        private readonly Queue<DateTime> _requests = new();
+        private readonly object _lock = new();
+
+        public int Count => _requests.Count;
+        public DateTime WindowResetTime { get; private set; }
+
+        public SlidingWindowCounter(int windowSeconds)
+        {
+            _windowSeconds = windowSeconds;
+            WindowResetTime = DateTime.UtcNow.AddSeconds(windowSeconds);
+        }
+
+        public int Increment()
+        {
+            lock (_lock)
+            {
+                var now = DateTime.UtcNow;
+                var windowStart = now.AddSeconds(-_windowSeconds);
+
+                // Remove requests outside the current window
+                while (_requests.Count > 0 && _requests.Peek() < windowStart)
+                {
+                    _requests.Dequeue();
+                }
+
+                // Add the current request
+                _requests.Enqueue(now);
+
+                // Update the window reset time
+                WindowResetTime = now.AddSeconds(_windowSeconds);
+
+                return _requests.Count;
+            }
+        }
+    }
+}

--- a/src/BookPetGroomingAPI.API/Program.cs
+++ b/src/BookPetGroomingAPI.API/Program.cs
@@ -8,13 +8,14 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.OpenApi.Models;
 using Serilog;
 using BookPetGroomingAPI.API.Filters;
+using BookPetGroomingAPI.API.Configuration;
 
 Console.WriteLine("Starting Program.cs execution..."); // Debug log
 Console.WriteLine("Creating WebApplication builder..."); // Debug log
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configurar Serilog
+// Configure Serilog
 var logsDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
 if (!Directory.Exists(logsDirectory))
 {
@@ -55,7 +56,7 @@ builder.Services.AddSwaggerGen(c =>
         }
     });
 
-    // Configurar Swagger para usar JWT
+    // Configure Swagger by use JWT 
     c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Description = "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
@@ -112,8 +113,11 @@ builder.Services.AddCors(options =>
     });
 });
 
-// Configurar autenticación JWT
+// Configure JWT Autentication 
 builder.Services.AddJwtAuthentication(builder.Configuration);
+
+// Configure rate limiting
+builder.Services.AddRateLimiting(builder.Configuration);
 
 var app = builder.Build();
 
@@ -134,6 +138,9 @@ app.UseResponseCompression();
 
 // Global error handling middleware
 app.UseMiddleware<ErrorHandlingMiddleware>();
+
+// Apply rate limiting
+app.UseRateLimiting();
 
 // Configure CORS
 app.UseCors("AllowAll");

--- a/src/BookPetGroomingAPI.API/appsettings.json
+++ b/src/BookPetGroomingAPI.API/appsettings.json
@@ -26,5 +26,20 @@
         "Issuer": "BookPetGroomingAPI",
         "Audience": "BookPetGroomingClients",
         "DurationInMinutes": 60
+    },
+    "RateLimiting": {
+        "WindowInSeconds": 60,
+        "MaxRequests": 100,
+        "EnableIpRateLimiting": true,
+        "EnableUserRateLimiting": true,
+        "AuthenticatedMaxRequests": 200,
+        "IpWhitelist": [
+            "127.0.0.1",
+            "::1"
+        ],
+        "EndpointWhitelist": [
+            "swagger",
+            "health"
+        ]
     }
 }


### PR DESCRIPTION
Introduce rate limiting to protect API endpoints from abuse. The middleware supports IP-based and user-based rate limiting, with configurable limits and whitelists. Added configuration options in appsettings.json, extension methods for service registration, and a middleware implementation to enforce rate limits. Also updated .gitignore to exclude docs and examples directories.