### PR TITLE
feat(appointments): implement pagination for appointment listings

### DIFF
--- a/src/BookPetGroomingAPI.API/Controllers/AppointmentController.cs
+++ b/src/BookPetGroomingAPI.API/Controllers/AppointmentController.cs
@@ -3,6 +3,7 @@ using BookPetGroomingAPI.Application.Features.Appointments.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using BookPetGroomingAPI.Shared.Common;
 namespace BookPetGroomingAPI.API.Controllers;
 
 [ApiVersion("1.0")]
@@ -23,16 +24,16 @@ public class AppointmentController : ApiControllerBase
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<List<AppointmentDto>>> GetAppointments()
+    public async Task<ActionResult<PaginatedList<AppointmentDto>>> GetAppointments([FromQuery] int pageNumber = 1, [FromQuery] int pageSize = 10)
     {
         try
         {
             _logger.LogInformation("Getting list of all appointments");
 
-            var query = new GetAppointmentsQuery();
+            var query = new GetAppointmentsQuery { PageNumber = pageNumber, PageSize = pageSize };
             var appointments = await Mediator(query);
 
-            _logger.LogInformation("Successfully retrieved {Count} appointments", appointments.Count);
+            _logger.LogInformation("Successfully retrieved {Count} appointments", appointments.Items.Count);
             return Ok(appointments);
         }
         catch (Exception ex)
@@ -118,9 +119,9 @@ public class AppointmentController : ApiControllerBase
     [HttpGet("groomer/{groomerId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<List<AppointmentDto>>> GetAppointmentsByGroomerId(int groomerId)
+    public async Task<ActionResult<PaginatedList<AppointmentDto>>> GetAppointmentsByGroomerId(int groomerId, [FromQuery] int pageNumber = 1, [FromQuery] int pageSize = 10)
     {
-        var query = new GetAppointmentsByGroomerIdQuery(groomerId);
+        var query = new GetAppointmentsByGroomerIdQuery(groomerId, pageNumber, pageSize);
         var appointments = await Mediator(query);
         return Ok(appointments);
     }

--- a/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/AppointmentDto.cs
+++ b/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/AppointmentDto.cs
@@ -35,6 +35,8 @@ public class AppointmentDto : IMapFrom<Appointment>
     public DateTime CreatedAt { get; set; }
     [SwaggerSchema(Description = "Date and time when the appointment was last updated.")]
     public DateTime UpdatedAt { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
     public void Mapping(Profile profile)
     {
         profile.CreateMap<Appointment, AppointmentDto>();

--- a/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsByGroomerIdQuery.cs
+++ b/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsByGroomerIdQuery.cs
@@ -1,3 +1,4 @@
+using BookPetGroomingAPI.Shared.Common;
 using MediatR;
 
 namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
@@ -5,11 +6,13 @@ namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
     /// <summary>
     /// Query to retrieve a list of appointments belonging to a specific groomer
     /// </summary>
-    public class GetAppointmentsByGroomerIdQuery(int groomerId) : IRequest<List<AppointmentDto>>
+    public class GetAppointmentsByGroomerIdQuery(int groomerId, int pageNumber, int pageSize) : IRequest<PaginatedList<AppointmentDto>>
     {
         /// <summary>
         /// The unique identifier of the groomer whose appointments are being requested 
         /// </summary>
         public int GroomerId { get; } = groomerId;
+        public int PageNumber { get; set; } = pageNumber;
+        public int PageSize { get; set; } = pageSize;
     }
 }

--- a/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsByGroomerIdQueryHandler.cs
+++ b/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsByGroomerIdQueryHandler.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using BookPetGroomingAPI.Domain.Interfaces;
+using BookPetGroomingAPI.Shared.Common;
 using MediatR;
 
 namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
@@ -7,12 +8,19 @@ namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
     /// <summary>
     /// Handler for processing the GetAppointmentsByGroomerIdQuery and returning the list of appointments for a groomer
     /// </summary>
-    public class GetAppointmentsByGroomerIdQueryHandler(IAppointmentRepository appointmentRepository, IMapper mapper) : IRequestHandler<GetAppointmentsByGroomerIdQuery, List<AppointmentDto>>
+    public class GetAppointmentsByGroomerIdQueryHandler(IAppointmentRepository appointmentRepository, IMapper mapper) : IRequestHandler<GetAppointmentsByGroomerIdQuery, PaginatedList<AppointmentDto>>
     {
-        public async Task<List<AppointmentDto>> Handle(GetAppointmentsByGroomerIdQuery request, CancellationToken cancellationToken)
+        public async Task<PaginatedList<AppointmentDto>> Handle(GetAppointmentsByGroomerIdQuery request, CancellationToken cancellationToken)
         {
-            var pets = await appointmentRepository.GetByGroomerIdAsync(request.GroomerId);
-            return mapper.Map<List<AppointmentDto>>(pets);
+            var query = appointmentRepository.GetAllQueryable().Where(a => a.GroomerId == request.GroomerId);
+
+            var paginatedAppointments = await PaginatedList<AppointmentDto>.CreateAsync(
+                query.Select(a => mapper.Map<AppointmentDto>(a)),
+                request.PageNumber, // Default to page 1 if not provided
+                request.PageSize  // Default to page size 10 if not provided
+            );
+
+            return paginatedAppointments;
         }
     }
 }

--- a/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsQuery.cs
+++ b/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsQuery.cs
@@ -1,8 +1,11 @@
+using BookPetGroomingAPI.Shared.Common;
 using MediatR;
 
 namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
 {
-    public class GetAppointmentsQuery : IRequest<List<AppointmentDto>>
+    public class GetAppointmentsQuery : IRequest<PaginatedList<AppointmentDto>>
     {
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
     }
 }

--- a/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsQueryHandler.cs
+++ b/src/BookPetGroomingAPI.Application/Features/Appointments/Queries/GetAppointmentsQueryHandler.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using BookPetGroomingAPI.Shared.Common;
 using BookPetGroomingAPI.Domain.Interfaces;
 using MediatR;
 
@@ -12,7 +13,7 @@ namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
     /// </remarks>
     /// <param name="appointmentRepository">Repository for appointment operations</param>
     /// <param name="mapper">Mapping service</param>
-    public class GetAppointmentsQueryHandler(IAppointmentRepository appointmentRepository, IMapper mapper) : IRequestHandler<GetAppointmentsQuery, List<AppointmentDto>>
+    public class GetAppointmentsQueryHandler(IAppointmentRepository appointmentRepository, IMapper mapper) : IRequestHandler<GetAppointmentsQuery, PaginatedList<AppointmentDto>>
     {
 
         /// <summary>
@@ -21,10 +22,16 @@ namespace BookPetGroomingAPI.Application.Features.Appointments.Queries
         /// <param name="request">The GetAppointmentsQuery</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of appointment DTOs</returns>
-        public async Task<List<AppointmentDto>> Handle(GetAppointmentsQuery request, CancellationToken cancellationToken)
+        public async Task<PaginatedList<AppointmentDto>> Handle(GetAppointmentsQuery request, CancellationToken cancellationToken)
         {
-            var appointments = await appointmentRepository.GetAllAsync();
-            return mapper.Map<List<AppointmentDto>>(appointments);
+            var query = appointmentRepository.GetAllQueryable();
+            var paginatedAppointments = await PaginatedList<AppointmentDto>.CreateAsync(
+                query.Select(a => mapper.Map<AppointmentDto>(a)),
+                request.PageNumber,
+                request.PageSize
+            );
+
+            return paginatedAppointments;
         }
     }
 }

--- a/src/BookPetGroomingAPI.Domain/Interfaces/IAppointmentRepository.cs
+++ b/src/BookPetGroomingAPI.Domain/Interfaces/IAppointmentRepository.cs
@@ -14,6 +14,7 @@ public interface IAppointmentRepository
     Task<IEnumerable<Appointment>> GetByPetIdAsync(int petId);
     Task<IEnumerable<Appointment>> GetByAppointmentDateAsync(DateTime appointmentDate);
     Task<IEnumerable<Appointment>> GetByStatusAsync(string status);
+    IQueryable<Appointment> GetAllQueryable();
     Task<int> AddAsync(Appointment appointment);
     Task UpdateAsync(Appointment appointment);
     Task DeleteAsync(int id);

--- a/src/BookPetGroomingAPI.Infrastructure/Persistence/Repositories/AppointmentRepository.cs
+++ b/src/BookPetGroomingAPI.Infrastructure/Persistence/Repositories/AppointmentRepository.cs
@@ -19,6 +19,7 @@ public class AppointmentRepository(ApplicationDbContext context) : IAppointmentR
             .FirstOrDefaultAsync(a => a.AppointmentId == id);
     }
 
+
     public async Task<IEnumerable<Appointment>> GetAllAsync()
     {
         return await _context.Appointments
@@ -89,6 +90,13 @@ public class AppointmentRepository(ApplicationDbContext context) : IAppointmentR
             .Include(a => a.Groomer)
             .Where(a => a.Status == status)
             .ToListAsync();
+    }
+
+    public IQueryable<Appointment> GetAllQueryable()
+    {
+        return _context.Appointments
+            .Include(a => a.Pet)
+            .Include(a => a.Groomer);
     }
 
     public async Task DeleteAsync(int id)

--- a/src/BookPetGroomingAPI.Shared/BookPetGroomingAPI.Shared.csproj
+++ b/src/BookPetGroomingAPI.Shared/BookPetGroomingAPI.Shared.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="14.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     </ItemGroup>

--- a/src/BookPetGroomingAPI.Shared/Common/PaginatedList.cs
+++ b/src/BookPetGroomingAPI.Shared/Common/PaginatedList.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BookPetGroomingAPI.Shared.Common;
+
+public class PaginatedList<T>(List<T> items, int count, int pageNumber, int pageSize)
+{
+    public List<T> Items { get; } = items;
+    public int PageNumber { get; } = pageNumber;
+    public int TotalPages { get; } = (int)Math.Ceiling(count / (double)pageSize);
+    public int TotalCount { get; } = count;
+
+    public bool HasPreviousPage => PageNumber > 1;
+    public bool HasNextPage => PageNumber < TotalPages;
+
+    public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> source, int pageNumber, int pageSize)
+    {
+        var count = await source.CountAsync();
+        var items = await source
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+           .ToListAsync();
+
+        return new PaginatedList<T>(items, count, pageNumber, pageSize);
+    }
+}

--- a/src/BookPetGroomingAPI.Shared/Common/PaginationParams.cs
+++ b/src/BookPetGroomingAPI.Shared/Common/PaginationParams.cs
@@ -1,0 +1,14 @@
+namespace BookPetGroomingAPI.Shared.Common;
+
+public class PaginationParams
+{
+    private const int MaxPageSize = 50;
+    private int _pageSize = 10;
+
+    public int PageNumber { get; set; } = 1;
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = (value > MaxPageSize) ? MaxPageSize : value;
+    }
+}


### PR DESCRIPTION
Add pagination support to appointment queries by:
- Creating PaginationParams and PaginatedList classes
- Modifying repository to expose IQueryable
- Updating query handlers to return paginated results
- Adding pagination parameters to API endpoints

This improves performance for clients by allowing them to request smaller chunks of data rather than loading all appointments at once.